### PR TITLE
Add support for VisImage, VisList, VisScrollPane, VisSelectBox, VisTree

### DIFF
--- a/src/com/github/czyzby/lml/vis/parser/impl/VisLmlSyntax.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/VisLmlSyntax.java
@@ -22,10 +22,15 @@ import com.github.czyzby.lml.vis.parser.impl.attribute.window.CloseOnEscapeLmlAt
 import com.github.czyzby.lml.vis.parser.impl.attribute.window.OnResultLmlAttribute;
 import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisDialogLmlTagProvider;
 import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisImageButtonLmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisImageLmlTagProvider;
 import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisImageTextButtonLmlTagProvider;
 import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisLabelLmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisListLmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisScrollPaneLmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisSelectBoxLmlTagProvider;
 import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisTableLmlTagProvider;
 import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisTextButtonLmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisTreeLmlTagProvider;
 import com.github.czyzby.lml.vis.parser.impl.tag.provider.VisWindowLmlTagProvider;
 import com.kotcrab.vis.ui.widget.VisDialog;
 
@@ -82,10 +87,15 @@ public class VisLmlSyntax extends DefaultLmlSyntax {
         // Vis actors:
         addTagProvider(new VisDialogLmlTagProvider(), "dialog", "visDialog", "popup");
         addTagProvider(new VisImageButtonLmlTagProvider(), "imageButton", "visImageButton");
+        addTagProvider(new VisImageLmlTagProvider(), "image", "img", "icon");
         addTagProvider(new VisImageTextButtonLmlTagProvider(), "imageTextButton", "visImageTextButton");
         addTagProvider(new VisLabelLmlTagProvider(), "label", "visLabel", "text", "txt", "li");
+        addTagProvider(new VisListLmlTagProvider(), "list", "ul");
+        addTagProvider(new VisScrollPaneLmlTagProvider(), "scrollPane", "scroll", "scrollable");
+        addTagProvider(new VisSelectBoxLmlTagProvider(), "select", "selectBox");
         addTagProvider(new VisTableLmlTagProvider(), "table", "visTable", "div", "td", "th");
         addTagProvider(new VisTextButtonLmlTagProvider(), "textButton", "visTextButton", "a");
+        addTagProvider(new VisTreeLmlTagProvider(), "tree", "root");
         addTagProvider(new VisWindowLmlTagProvider(), "window", "visWindow");
         // TODO register other Vis tags
     }

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/VisImageLmlTag.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/VisImageLmlTag.java
@@ -1,0 +1,28 @@
+package com.github.czyzby.lml.vis.parser.impl.tag;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.impl.tag.actor.ImageLmlTag;
+import com.github.czyzby.lml.parser.tag.LmlActorBuilder;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.kotcrab.vis.ui.widget.VisImage;
+
+/**
+ * Handles {@link VisImage} actor. Mapped to "image", "img", "icon".
+ * @author Kotcrab
+ */
+public class VisImageLmlTag extends ImageLmlTag {
+    public VisImageLmlTag(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        super(parser, parentTag, rawTagData);
+    }
+
+    @Override
+    protected Actor getNewInstanceOfActor(LmlActorBuilder builder) {
+        return new VisImage(getSkin(builder).getDrawable(builder.getStyleName()));
+    }
+
+    @Override
+    protected Class<?> getActorType() {
+        return VisImage.class;
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/VisListLmlTag.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/VisListLmlTag.java
@@ -1,0 +1,29 @@
+package com.github.czyzby.lml.vis.parser.impl.tag;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.impl.tag.actor.ListLmlTag;
+import com.github.czyzby.lml.parser.tag.LmlActorBuilder;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.kotcrab.vis.ui.widget.VisList;
+
+/**
+ * Handles {@link VisList} actors. Converts label and text button children to items by extracting their text; does not
+ * accept any other child tags. Appends plain text lines between tags as its list items. Mapped to "list", "ul".
+ * @author Kotcrab
+ */
+public class VisListLmlTag extends ListLmlTag {
+    public VisListLmlTag(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        super(parser, parentTag, rawTagData);
+    }
+
+    @Override
+    protected Actor getNewInstanceOfActor(LmlActorBuilder builder) {
+        return new VisList<String>(builder.getStyleName());
+    }
+
+    @Override
+    protected Class<?> getActorType() {
+        return VisList.class;
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/VisScrollPaneLmlTag.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/VisScrollPaneLmlTag.java
@@ -1,0 +1,30 @@
+package com.github.czyzby.lml.vis.parser.impl.tag;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.impl.tag.actor.ScrollPaneLmlTag;
+import com.github.czyzby.lml.parser.tag.LmlActorBuilder;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.kotcrab.vis.ui.widget.VisScrollPane;
+
+/**
+ * Handles {@link VisScrollPane} actor. Can have a single child tag which will be set as scroll pane's managed widget.
+ * Parses plain text between tags to a label and sets it as its managed widget. Mapped to "scrollPane", "scroll",
+ * "scrollable".
+ * @author Kotcrab
+ */
+public class VisScrollPaneLmlTag extends ScrollPaneLmlTag {
+    public VisScrollPaneLmlTag(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        super(parser, parentTag, rawTagData);
+    }
+
+    @Override
+    protected Actor getNewInstanceOfActor(LmlActorBuilder builder) {
+        return new VisScrollPane(null, builder.getStyleName());
+    }
+
+    @Override
+    protected Class<?> getActorType() {
+        return VisScrollPane.class;
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/VisSelectBoxLmlTag.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/VisSelectBoxLmlTag.java
@@ -1,0 +1,30 @@
+package com.github.czyzby.lml.vis.parser.impl.tag;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.impl.tag.actor.SelectBoxLmlTag;
+import com.github.czyzby.lml.parser.tag.LmlActorBuilder;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.kotcrab.vis.ui.widget.VisSelectBox;
+
+/**
+ * Handles {@link VisSelectBox} actor. Like the List widget it wraps, select box can handle only string data. Converts
+ * label and text button children to items by extracting their text; does not accept any other child tags. Appends plain
+ * text lines between tags as its items. Mapped to "select", "selectBox".
+ * @author Kotcrab
+ */
+public class VisSelectBoxLmlTag extends SelectBoxLmlTag {
+    public VisSelectBoxLmlTag(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        super(parser, parentTag, rawTagData);
+    }
+
+    @Override
+    protected Actor getNewInstanceOfActor(LmlActorBuilder builder) {
+        return new VisSelectBox(builder.getStyleName());
+    }
+
+    @Override
+    protected Class<?> getActorType() {
+        return VisSelectBox.class;
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/VisTreeLmlTag.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/VisTreeLmlTag.java
@@ -1,0 +1,31 @@
+package com.github.czyzby.lml.vis.parser.impl.tag;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.ui.Tree;
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.impl.tag.actor.TreeLmlTag;
+import com.github.czyzby.lml.parser.tag.LmlActorBuilder;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.kotcrab.vis.ui.widget.VisTree;
+
+/**
+ * Handles {@link Tree} actor. Mapped to "tree", "root". Allows the use of "node" attribute in children tags. Adds
+ * plain text between tags as new label nodes. Mapped to "tree", "node".
+ * @author Kotcrab
+ * @see com.github.czyzby.lml.parser.impl.attribute.TreeNodeLmlAttribute
+ */
+public class VisTreeLmlTag extends TreeLmlTag {
+    public VisTreeLmlTag(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        super(parser, parentTag, rawTagData);
+    }
+
+    @Override
+    protected Actor getNewInstanceOfActor(LmlActorBuilder builder) {
+        return new VisTree(builder.getStyleName());
+    }
+
+    @Override
+    protected Class<?> getActorType() {
+        return VisTree.class;
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisImageLmlTagProvider.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisImageLmlTagProvider.java
@@ -1,0 +1,17 @@
+package com.github.czyzby.lml.vis.parser.impl.tag.provider;
+
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.github.czyzby.lml.parser.tag.LmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.VisImageLmlTag;
+
+/**
+ * Provides VisImage tags.
+ * @author Kotcrab
+ */
+public class VisImageLmlTagProvider implements LmlTagProvider {
+    @Override
+    public LmlTag create(final LmlParser parser, final LmlTag parentTag, final String rawTagData) {
+        return new VisImageLmlTag(parser, parentTag, rawTagData);
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisListLmlTagProvider.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisListLmlTagProvider.java
@@ -1,0 +1,17 @@
+package com.github.czyzby.lml.vis.parser.impl.tag.provider;
+
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.github.czyzby.lml.parser.tag.LmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.VisListLmlTag;
+
+/**
+ * Provider VisList tags
+ * @author Kotcrab
+ */
+public class VisListLmlTagProvider implements LmlTagProvider {
+    @Override
+    public LmlTag create(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        return new VisListLmlTag(parser, parentTag, rawTagData);
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisScrollPaneLmlTagProvider.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisScrollPaneLmlTagProvider.java
@@ -1,0 +1,17 @@
+package com.github.czyzby.lml.vis.parser.impl.tag.provider;
+
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.github.czyzby.lml.parser.tag.LmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.VisScrollPaneLmlTag;
+
+/**
+ * Handles VisScrollPane tags
+ * @author Kotcrab
+ */
+public class VisScrollPaneLmlTagProvider implements LmlTagProvider {
+    @Override
+    public LmlTag create(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        return new VisScrollPaneLmlTag(parser, parentTag, rawTagData);
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisSelectBoxLmlTagProvider.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisSelectBoxLmlTagProvider.java
@@ -1,0 +1,17 @@
+package com.github.czyzby.lml.vis.parser.impl.tag.provider;
+
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.github.czyzby.lml.parser.tag.LmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.VisSelectBoxLmlTag;
+
+/**
+ * Handles VisSelectBox tags
+ * @author Kotcrab
+ */
+public class VisSelectBoxLmlTagProvider implements LmlTagProvider {
+    @Override
+    public LmlTag create(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        return new VisSelectBoxLmlTag(parser, parentTag, rawTagData);
+    }
+}

--- a/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisTreeLmlTagProvider.java
+++ b/src/com/github/czyzby/lml/vis/parser/impl/tag/provider/VisTreeLmlTagProvider.java
@@ -1,0 +1,17 @@
+package com.github.czyzby.lml.vis.parser.impl.tag.provider;
+
+import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.github.czyzby.lml.parser.tag.LmlTagProvider;
+import com.github.czyzby.lml.vis.parser.impl.tag.VisTreeLmlTag;
+
+/**
+ * Handles VisTree tags
+ * @author Kotcrab
+ */
+public class VisTreeLmlTagProvider implements LmlTagProvider {
+    @Override
+    public LmlTag create(LmlParser parser, LmlTag parentTag, String rawTagData) {
+        return new VisTreeLmlTag(parser, parentTag, rawTagData);
+    }
+}


### PR DESCRIPTION
Added support for widgets extending standard scene2d.ui (see https://github.com/czyzby/gdx-lml-vis/issues/1)

@czyzby please review. What should I do with Javadoc if i extend LmlTag from scene2d.ui? Now I just copied it from parent class.
